### PR TITLE
[Issue #1] Set up transformation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 .mypy_cache/
 .venv/
 .htmlcov/
+
+# sample output
+output/**

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Billy Daly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: help install format lint type-check test test-cov checks clean
 
+RUN_CMD := poetry run
+
 # Default target
 help:
 	@echo "Available targets:"
@@ -14,40 +16,45 @@ help:
 
 # Install dependencies
 install:
-	poetry install
+	$(RUN_CMD) poetry install
 
 # Format code with black
 format:
 	@echo "==> Formatting code with black..."
-	poetry run black .
+	$(RUN_CMD) black .
 
 format-check:
 	@echo "==> Checking code formatting with black..."
-	poetry run black --check .
+	$(RUN_CMD) black --check .
 
 lint-fix:
 	@echo "==> Fixing linting errors with ruff..."
-	poetry run ruff check --fix .
+	$(RUN_CMD) ruff check --fix .
 
 # Lint code with ruff
 lint:
 	@echo "==> Linting code with ruff..."
-	poetry run ruff check .
+	$(RUN_CMD) ruff check .
 
 # Run type checking with mypy
 type-check:
 	@echo "==> Running type checks with mypy..."
-	poetry run mypy json_mapper/
+	$(RUN_CMD) mypy json_mapper/
 
 # Run tests without coverage
 test:
 	@echo "==> Running tests..."
-	poetry run pytest
+	$(RUN_CMD) pytest
 
 # Run tests with coverage
 test-cov:
 	@echo "==> Running tests with coverage..."
-	poetry run pytest --cov=json_mapper --cov-report=term-missing --cov-fail-under=95
+	$(RUN_CMD) pytest --cov=json_mapper --cov-report=term-missing --cov-fail-under=95
+
+# Run example
+example:
+	@echo "==> Running example..."
+	$(RUN_CMD) json-mapper examples/input.json -m examples/mapping.json
 
 # Run all checks (format, lint, type-check, and test with coverage)
 checks: format-check lint type-check test-cov

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ format:
 	@echo "==> Formatting code with black..."
 	poetry run black json_mapper/
 
+format-check:
+	@echo "==> Checking code formatting with black..."
+	poetry run black --check json_mapper/
+
+lint-fix:
+	@echo "==> Fixing linting errors with ruff..."
+	poetry run ruff check --fix json_mapper/
+
 # Lint code with ruff
 lint:
 	@echo "==> Linting code with ruff..."
@@ -42,8 +50,11 @@ test-cov:
 	poetry run pytest --cov=json_mapper --cov-report=term-missing --cov-report=html
 
 # Run all checks (format, lint, type-check, and test with coverage)
-checks: format lint type-check test-cov
+checks: format-check lint type-check test-cov
 	@echo "==> All checks passed! ✓"
+
+fix: format lint-fix
+	@echo "==> All fixes applied! ✓"
 
 # Clean build artifacts and cache
 clean:

--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,20 @@ install:
 # Format code with black
 format:
 	@echo "==> Formatting code with black..."
-	poetry run black json_mapper/
+	poetry run black .
 
 format-check:
 	@echo "==> Checking code formatting with black..."
-	poetry run black --check json_mapper/
+	poetry run black --check .
 
 lint-fix:
 	@echo "==> Fixing linting errors with ruff..."
-	poetry run ruff check --fix json_mapper/
+	poetry run ruff check --fix .
 
 # Lint code with ruff
 lint:
 	@echo "==> Linting code with ruff..."
-	poetry run ruff check json_mapper/
+	poetry run ruff check .
 
 # Run type checking with mypy
 type-check:
@@ -47,7 +47,7 @@ test:
 # Run tests with coverage
 test-cov:
 	@echo "==> Running tests with coverage..."
-	poetry run pytest --cov=json_mapper --cov-report=term-missing --cov-report=html
+	poetry run pytest --cov=json_mapper --cov-report=term-missing --cov-fail-under=95
 
 # Run all checks (format, lint, type-check, and test with coverage)
 checks: format-check lint type-check test-cov

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install format lint type-check test test-cov checks clean
+.PHONY: help install format format-check lint lint-fix type-check test test-cov checks clean examples
 
 RUN_CMD := poetry run
 
@@ -52,15 +52,18 @@ test-cov:
 	$(RUN_CMD) pytest --cov=json_mapper --cov-report=term-missing --cov-fail-under=95
 
 # Run example
-example:
-	@echo "==> Running example..."
+examples:
+	@echo "==> Running examples..."
+	@echo "\n\n==> Example 1: Print to stdout"
 	$(RUN_CMD) json-mapper examples/input.json -m examples/mapping.json
+	@echo "\n\n==> Example 2: Print to file"
+	$(RUN_CMD) json-mapper examples/input.json -m examples/mapping.json -o output/output.json
 
 # Run all checks (format, lint, type-check, and test with coverage)
 checks: format-check lint type-check test-cov
 	@echo "==> All checks passed! ✓"
 
-fix: format lint-fix
+fix: lint-fix format
 	@echo "==> All fixes applied! ✓"
 
 # Clean build artifacts and cache

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ A Python CLI tool that translates JSON values from one format to another using a
 ```bash
 # Install with poetry
 poetry install
-
-# Or install in development mode
-pip install -e .
 ```
 
 ## Usage
@@ -18,13 +15,23 @@ pip install -e .
 
 ```bash
 # Map a JSON file using a mapping configuration
-json-mapper input.json -m mapping.json -o output.json
+poetry run json-mapper examples/input.json -m examples/mapping.json -o output.json
 
-# Read from stdin, write to stdout
-cat input.json | json-mapper -m mapping.json
+# Print result to stdout 
+poetry run json-mapper examples/input.json -m examples/mapping.json
+```
 
-# Use verbose mode to see what's happening
-json-mapper input.json -m mapping.json -o output.json -v
+You should see the following output:
+
+```json
+{
+  "name": {
+    "firstName": "John",
+    "lastName": "Doe"
+  },
+  "email": "john@example.com",
+  "age": 30
+}
 ```
 
 ### Command-Line Options
@@ -41,8 +48,6 @@ options:
   -o OUTPUT, --output OUTPUT
                         Output file (default: stdout)
   --indent INDENT       Number of spaces for JSON indentation (default: 2)
-  --compact             Output compact JSON (no indentation)
-  -v, --verbose         Enable verbose output
 ```
 
 ## Examples
@@ -52,9 +57,10 @@ options:
 **input.json:**
 ```json
 {
-  "name": "John Doe",
+  "first_name": "John Doe",
+  "last_name": "Doe",
   "age": 30,
-  "email": "john@example.com"
+  "email_address": "john@example.com"
 }
 ```
 
@@ -62,8 +68,12 @@ options:
 ```json
 {
   "fields": {
-    "name": "fullName",
-    "email": "emailAddress"
+    "name": {
+      "firstName": { "field": "first_name" },
+      "lastName": { "field": "last_name" }
+    },
+    "email": { "field": "email_address" },
+    "age": { "field": "age" }
   }
 }
 ```
@@ -71,6 +81,18 @@ options:
 **Command:**
 ```bash
 json-mapper input.json -m mapping.json -o output.json
+```
+
+**Output:**
+```json
+{
+  "name": {
+    "firstName": "John",
+    "lastName": "Doe"
+  },
+  "email": "john@example.com",
+  "age": 30
+}
 ```
 
 ### Example 2: Pipeline Usage

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ make fix
 # Run all checks (formatting, linting, type-checking, and tests with coverage)
 make checks
 
-# Run example
-make example
+# Run examples
+make examples
 ```
 
 ### Individual Commands

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 A Python CLI tool that translates JSON values from one format to another using a declarative mapping configuration.
 
+## Table of Contents
+- [Installation](#installation)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Development](#development)
+- [Project Structure](#project-structure)
+
 ## Installation
+
+Prerequisites:
+- Python 3.13+
+- Poetry
 
 ```bash
 # Install with poetry
@@ -25,12 +36,28 @@ You should see the following output:
 
 ```json
 {
-  "name": {
-    "firstName": "John",
-    "lastName": "Doe"
+  "title": "Research Grant",
+  "opportunityCode": "ABC-123-12345",
+  "status": "open",
+  "agency": {
+    "name": "Department of Examples",
+    "type": "Federal"
   },
-  "email": "john@example.com",
-  "age": 30
+  "contact": {
+    "name": "Jane Smith",
+    "email": "jane.smith@example.gov",
+    "phone": "555-0100"
+  },
+  "funding": {
+    "minimum": 10000,
+    "maximum": 100000,
+    "currency": "USD"
+  },
+  "eligibility": [
+    "state_governments",
+    "nonprofit"
+  ],
+  "deadline": "2025-07-15"
 }
 ```
 
@@ -49,6 +76,15 @@ options:
                         Output file (default: stdout)
   --indent INDENT       Number of spaces for JSON indentation (default: 2)
 ```
+
+### Supported Transformations
+
+| Transformation | Handler  | Description                                                  | Example                                                                    |
+| -------------- | -------- | ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Field plucking | `field`  | Plucks a value from the input data using a dot-notation path | `{"field": "name.firstName"}`                                              |
+| Literal value  | --       | Passes through a literal value unchanged                     | `{"amount": 42}`                                                           |
+| Switch         | `switch` | Performs a case-based lookup based on a field value          | `{"switch": {"field": "status", "case": {...}, "default": "unknown"}}`     |
+| Concatenation  | `concat` | Joins multiple values together                               | `{"concat": {"parts": [{"field": "amount"}, " ", {"field": "currency"}]}}` |
 
 ## Examples
 
@@ -95,23 +131,87 @@ json-mapper input.json -m mapping.json -o output.json
 }
 ```
 
-### Example 2: Pipeline Usage
+### Example 2: Concatenation
 
-```bash
-# Use in a data processing pipeline
-curl https://api.example.com/data.json | json-mapper -m mapping.json | jq '.results'
+**input.json:**
+```json
+{
+  "first_name": "John",
+  "last_name": "Doe"
+}
+```
+
+**mapping.json:**
+```json
+{
+  "fullName": {
+    "concat": {
+      "parts": [
+        { "field": "first_name" },
+        " ",
+        { "field": "last_name" }
+      ]
+    }
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "fullName": "John Doe"
+}
+```
+
+### Example 3: Switch
+
+**input.json:**
+```json
+{
+  "opportunity_status": "posted"
+}
+```
+
+**mapping.json:**
+```json
+{
+  "status": {
+    "switch": {
+      "field": "opportunity_status",
+      "case": {
+        "posted": "open",
+        "forecasted": "upcoming",
+        "archived": "closed"
+      },
+      "default": "unknown"
+    }
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "status": "open"
+}
 ```
 
 ## Development
 
-### Quick Start
+### Quickstart commands
 
 ```bash
 # Install dependencies
 make install
 
+# Fix auto-formatting and linting errors
+make fix
+
 # Run all checks (formatting, linting, type-checking, and tests with coverage)
 make checks
+
+# Run example
+make example
 ```
 
 ### Individual Commands
@@ -142,10 +242,10 @@ If you prefer to run commands directly:
 
 ```bash
 # Format code
-poetry run black json_mapper/
+poetry run black .
 
 # Lint code
-poetry run ruff check json_mapper/
+poetry run ruff check .
 
 # Type check
 poetry run mypy json_mapper/
@@ -160,15 +260,19 @@ poetry run pytest --cov=json_mapper --cov-report=term-missing --cov-report=html
 ## Project Structure
 
 ```
-sample-python-tool/
-├── json_mapper/
-│   ├── __init__.py       # Package initialization
-│   └── cli.py            # CLI implementation with argparse
-├── pyproject.toml        # Project configuration and dependencies
-├── poetry.lock           # Locked dependencies
-└── README.md            # This file
+root/
+├── examples/           # Example input and mapping files
+│   ├── input.json      # Sample input data
+│   └── mapping.json    # Sample mapping configuration
+├── json_mapper/        # The package
+│   ├── transform.py    # Core transformation logic
+│   ├── utils.py        # Utility functions
+│   └── cli.py          # CLI implementation with argparse
+├── tests/              # Test suite
+│   ├── test_transform.py   # Transformation tests
+│   ├── test_utils.py       # Utility function tests
+│   └── test_cli.py         # CLI tests
+├── Makefile            # Common development tasks
+├── pyproject.toml      # Project configuration and dependencies
+└── poetry.lock         # Locked dependencies
 ```
-
-## License
-
-MIT

--- a/examples/input.json
+++ b/examples/input.json
@@ -1,0 +1,16 @@
+{
+  "agency_name": "Department of Examples",
+  "opportunity_id": 12345,
+  "opportunity_number": "ABC-123",
+  "opportunity_status": "posted",
+  "opportunity_title": "Research Grant",
+  "contact_name": "Jane Smith",
+  "contact_email": "jane.smith@example.gov",
+  "contact_phone": "555-0100",
+  "summary": {
+    "applicant_types": ["state_governments", "nonprofit"],
+    "award_ceiling": 100000,
+    "award_floor": 10000,
+    "close_date": "2025-07-15"
+  }
+}

--- a/examples/mapping.json
+++ b/examples/mapping.json
@@ -1,0 +1,39 @@
+{
+  "title": {"field": "opportunity_title"},
+  "opportunityCode": {
+    "concat": {
+      "parts": [
+        {"field": "opportunity_number"},
+        "-",
+        {"field": "opportunity_id"}
+      ]
+    }
+  },
+  "status": {
+    "switch": {
+      "field": "opportunity_status",
+      "case": {
+        "forecasted": "upcoming",
+        "posted": "open",
+        "archived": "closed"
+      },
+      "default": "unknown"
+    }
+  },
+  "agency": {
+    "name": {"field": "agency_name"},
+    "type": "Federal"
+  },
+  "contact": {
+    "name": {"field": "contact_name"},
+    "email": {"field": "contact_email"},
+    "phone": {"field": "contact_phone"}
+  },
+  "funding": {
+    "minimum": {"field": "summary.award_floor"},
+    "maximum": {"field": "summary.award_ceiling"},
+    "currency": "USD"
+  },
+  "eligibility": {"field": "summary.applicant_types"},
+  "deadline": {"field": "summary.close_date"}
+}

--- a/json_mapper/cli.py
+++ b/json_mapper/cli.py
@@ -3,62 +3,46 @@
 import argparse
 import json
 import sys
-from pathlib import Path
+from dataclasses import dataclass
 from typing import Any
 
+from json_mapper.transform import transform_from_mapping
+from json_mapper.utils import load_json_file, save_json_file
 
-def load_json_file(file_path: str) -> dict[str, Any]:
-    """Load and parse a JSON file.
-
-    Args:
-        file_path: Path to the JSON file
-
-    Returns:
-        Parsed JSON data as a dictionary
-
-    Raises:
-        FileNotFoundError: If the file doesn't exist
-        json.JSONDecodeError: If the file contains invalid JSON
-    """
-    path = Path(file_path)
-    if not path.exists():
-        raise FileNotFoundError(f"File not found: {file_path}")
-
-    with path.open("r") as f:
-        data = json.load(f)
-        if not isinstance(data, dict):
-            raise TypeError(f"Expected JSON object, got {type(data).__name__}")
-        return data
+# ############################################################
+# CLI Arguments and Parser
+# ############################################################
 
 
-def save_json_file(data: dict[str, Any], file_path: str, indent: int = 2) -> None:
-    """Save data to a JSON file.
+@dataclass
+class CliArgs:
+    """Dataclass representing parsed CLI arguments."""
 
-    Args:
-        data: Dictionary to save as JSON
-        file_path: Path where the JSON file should be saved
-        indent: Number of spaces for indentation (default: 2)
-    """
-    path = Path(file_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    mapping: str
+    input: str | None = None
+    output: str | None = None
+    indent: int = 2
+    compact: bool = False
+    verbose: bool = False
 
-    with path.open("w") as f:
-        json.dump(data, f, indent=indent)
+    @classmethod
+    def from_namespace(cls, args: argparse.Namespace) -> "CliArgs":
+        """Create CliArgs from argparse.Namespace.
 
+        Args:
+            args: Parsed arguments from argparse
 
-def map_json(input_data: dict[str, Any], mapping_config: dict[str, Any]) -> dict[str, Any]:
-    """Map JSON data according to a mapping configuration.
-
-    Args:
-        input_data: The input JSON data to transform
-        mapping_config: The mapping configuration that defines the transformation
-
-    Returns:
-        Transformed JSON data
-    """
-    # Placeholder implementation - this is where your mapping logic would go
-    # For now, just return the input data
-    return input_data
+        Returns:
+            CliArgs instance
+        """
+        return cls(
+            mapping=args.mapping,
+            input=args.input,
+            output=args.output,
+            indent=args.indent,
+            compact=args.compact,
+            verbose=args.verbose,
+        )
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -88,7 +72,9 @@ Examples:
     parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
 
     # Input file argument
-    parser.add_argument("input", nargs="?", help="Input JSON file (use '-' or omit for stdin)")
+    parser.add_argument(
+        "input", nargs="?", help="Input JSON file (use '-' or omit for stdin)"
+    )
 
     # Mapping configuration
     parser.add_argument(
@@ -110,56 +96,121 @@ Examples:
     )
 
     parser.add_argument(
-        "--compact", action="store_true", help="Output compact JSON (no indentation)"
+        "--compact",
+        action="store_true",
+        help="Output compact JSON (no indentation)",
     )
 
     # Verbose output
-    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
+    )
 
     return parser
 
 
-def main() -> int:
-    """Main entry point for the CLI.
+# ############################################################
+# Transformation Steps
+# ############################################################
+
+
+def load_mapping(args: CliArgs) -> dict[str, Any]:
+    """Load the mapping configuration file.
+
+    Args:
+        args: Parsed CLI arguments
+
+    Returns:
+        Mapping configuration dictionary
+    """
+    if args.verbose:
+        print(f"Loading mapping config from: {args.mapping}", file=sys.stderr)
+    return load_json_file(args.mapping)
+
+
+def load_input(args: CliArgs) -> dict[str, Any]:
+    """Load input data from file or stdin.
+
+    Args:
+        args: Parsed CLI arguments
+
+    Returns:
+        Input data dictionary
+    """
+    if args.input and args.input != "-":
+        if args.verbose:
+            print(f"Loading input from: {args.input}", file=sys.stderr)
+        return load_json_file(args.input)
+    else:
+        if args.verbose:
+            print("Reading input from stdin", file=sys.stderr)
+        data = json.load(sys.stdin)
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected JSON object, got {type(data).__name__}")
+        return data
+
+
+def transform_input(
+    data: dict[str, Any],
+    mapping: dict[str, Any],
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Transform input data using the mapping configuration.
+
+    Args:
+        data: Input data to transform
+        mapping: Mapping configuration
+        verbose: Whether to print verbose output
+
+    Returns:
+        Transformed data dictionary
+    """
+    if verbose:
+        print("Performing JSON mapping...", file=sys.stderr)
+    return transform_from_mapping(data, mapping)
+
+
+def write_output(data: dict[str, Any], args: CliArgs) -> None:
+    """Write output data to file or stdout.
+
+    Args:
+        data: Output data to write
+        args: Parsed CLI arguments
+    """
+    indent = None if args.compact else args.indent
+
+    if args.output:
+        if args.verbose:
+            print(f"Writing output to: {args.output}", file=sys.stderr)
+        save_json_file(data, args.output, indent=indent or 2)
+    else:
+        json.dump(data, sys.stdout, indent=indent)
+        print()  # Add newline at the end
+
+
+# ############################################################
+# Run CLI
+# ############################################################
+
+
+def run_cli(args: CliArgs) -> int:
+    """Execute the CLI logic with parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments
 
     Returns:
         Exit code (0 for success, non-zero for errors)
     """
-    parser = create_parser()
-    args = parser.parse_args()
-
     try:
-        # Load mapping configuration
-        if args.verbose:
-            print(f"Loading mapping config from: {args.mapping}", file=sys.stderr)
-        mapping_config = load_json_file(args.mapping)
-
-        # Load input data
-        if args.input and args.input != "-":
-            if args.verbose:
-                print(f"Loading input from: {args.input}", file=sys.stderr)
-            input_data = load_json_file(args.input)
-        else:
-            if args.verbose:
-                print("Reading input from stdin", file=sys.stderr)
-            input_data = json.load(sys.stdin)
-
-        # Perform the mapping
-        if args.verbose:
-            print("Performing JSON mapping...", file=sys.stderr)
-        output_data = map_json(input_data, mapping_config)
-
-        # Determine indentation
-        indent = None if args.compact else args.indent
-
-        # Write output
-        if args.output:
-            if args.verbose:
-                print(f"Writing output to: {args.output}", file=sys.stderr)
-            save_json_file(output_data, args.output, indent=indent or 2)
-        else:
-            json.dump(output_data, sys.stdout, indent=indent)
-            print()  # Add newline at the end
+        mapping_config = load_mapping(args)
+        input_data = load_input(args)
+        output_data = transform_input(
+            data=input_data,
+            mapping=mapping_config,
+            verbose=args.verbose,
+        )
+        write_output(output_data, args)
 
         if args.verbose:
             print("Success!", file=sys.stderr)
@@ -172,9 +223,32 @@ def main() -> int:
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON - {e}", file=sys.stderr)
         return 1
+    except TypeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+
+# ############################################################
+# Main Entry Point
+# ############################################################
+
+
+def main() -> int:
+    """Main entry point for the CLI.
+
+    Returns:
+        Exit code (0 for success, non-zero for errors)
+    """
+    parser = create_parser()
+    namespace = parser.parse_args()
+    args = CliArgs.from_namespace(namespace)
+    return run_cli(args)
 
 
 if __name__ == "__main__":

--- a/json_mapper/cli.py
+++ b/json_mapper/cli.py
@@ -57,15 +57,14 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Map a JSON file using a mapping config
-  json-mapper input.json -m mapping.json -o output.json
+# Map a JSON file using a mapping config
+json-mapper input.json -m mapping.json -o output.json
 
-  # Map JSON from stdin and output to stdout
-  cat input.json | json-mapper -m mapping.json
+# Map JSON from stdin and output to stdout
+cat input.json | json-mapper -m mapping.json
 
-  # Display version information
-  json-mapper --version
-        """,
+# Display version information
+json-mapper --version""",
     )
 
     # Version argument

--- a/json_mapper/cli.py
+++ b/json_mapper/cli.py
@@ -19,11 +19,9 @@ class CliArgs:
     """Dataclass representing parsed CLI arguments."""
 
     mapping: str
-    input: str | None = None
+    input: str
     output: str | None = None
     indent: int = 2
-    compact: bool = False
-    verbose: bool = False
 
     @classmethod
     def from_namespace(cls, args: argparse.Namespace) -> "CliArgs":
@@ -40,8 +38,6 @@ class CliArgs:
             input=args.input,
             output=args.output,
             indent=args.indent,
-            compact=args.compact,
-            verbose=args.verbose,
         )
 
 
@@ -60,9 +56,6 @@ Examples:
 # Map a JSON file using a mapping config
 json-mapper input.json -m mapping.json -o output.json
 
-# Map JSON from stdin and output to stdout
-cat input.json | json-mapper -m mapping.json
-
 # Display version information
 json-mapper --version""",
     )
@@ -71,9 +64,7 @@ json-mapper --version""",
     parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
 
     # Input file argument
-    parser.add_argument(
-        "input", nargs="?", help="Input JSON file (use '-' or omit for stdin)"
-    )
+    parser.add_argument("input", help="Input JSON file")
 
     # Mapping configuration
     parser.add_argument(
@@ -94,17 +85,6 @@ json-mapper --version""",
         help="Number of spaces for JSON indentation (default: 2)",
     )
 
-    parser.add_argument(
-        "--compact",
-        action="store_true",
-        help="Output compact JSON (no indentation)",
-    )
-
-    # Verbose output
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose output"
-    )
-
     return parser
 
 
@@ -122,13 +102,11 @@ def load_mapping(args: CliArgs) -> dict[str, Any]:
     Returns:
         Mapping configuration dictionary
     """
-    if args.verbose:
-        print(f"Loading mapping config from: {args.mapping}", file=sys.stderr)
     return load_json_file(args.mapping)
 
 
 def load_input(args: CliArgs) -> dict[str, Any]:
-    """Load input data from file or stdin.
+    """Load input data from file.
 
     Args:
         args: Parsed CLI arguments
@@ -136,36 +114,22 @@ def load_input(args: CliArgs) -> dict[str, Any]:
     Returns:
         Input data dictionary
     """
-    if args.input and args.input != "-":
-        if args.verbose:
-            print(f"Loading input from: {args.input}", file=sys.stderr)
-        return load_json_file(args.input)
-    else:
-        if args.verbose:
-            print("Reading input from stdin", file=sys.stderr)
-        data = json.load(sys.stdin)
-        if not isinstance(data, dict):
-            raise TypeError(f"Expected JSON object, got {type(data).__name__}")
-        return data
+    return load_json_file(args.input)
 
 
 def transform_input(
     data: dict[str, Any],
     mapping: dict[str, Any],
-    verbose: bool = False,
 ) -> dict[str, Any]:
     """Transform input data using the mapping configuration.
 
     Args:
         data: Input data to transform
         mapping: Mapping configuration
-        verbose: Whether to print verbose output
 
     Returns:
         Transformed data dictionary
     """
-    if verbose:
-        print("Performing JSON mapping...", file=sys.stderr)
     return transform_from_mapping(data, mapping)
 
 
@@ -176,61 +140,11 @@ def write_output(data: dict[str, Any], args: CliArgs) -> None:
         data: Output data to write
         args: Parsed CLI arguments
     """
-    indent = None if args.compact else args.indent
-
     if args.output:
-        if args.verbose:
-            print(f"Writing output to: {args.output}", file=sys.stderr)
-        save_json_file(data, args.output, indent=indent or 2)
+        save_json_file(data, args.output, indent=args.indent)
     else:
-        json.dump(data, sys.stdout, indent=indent)
+        json.dump(data, sys.stdout, indent=args.indent)
         print()  # Add newline at the end
-
-
-# ############################################################
-# Run CLI
-# ############################################################
-
-
-def run_cli(args: CliArgs) -> int:
-    """Execute the CLI logic with parsed arguments.
-
-    Args:
-        args: Parsed CLI arguments
-
-    Returns:
-        Exit code (0 for success, non-zero for errors)
-    """
-    try:
-        mapping_config = load_mapping(args)
-        input_data = load_input(args)
-        output_data = transform_input(
-            data=input_data,
-            mapping=mapping_config,
-            verbose=args.verbose,
-        )
-        write_output(output_data, args)
-
-        if args.verbose:
-            print("Success!", file=sys.stderr)
-
-        return 0
-
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON - {e}", file=sys.stderr)
-        return 1
-    except TypeError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
 
 
 # ############################################################
@@ -244,10 +158,36 @@ def main() -> int:
     Returns:
         Exit code (0 for success, non-zero for errors)
     """
-    parser = create_parser()
-    namespace = parser.parse_args()
-    args = CliArgs.from_namespace(namespace)
-    return run_cli(args)
+    try:
+        # Parse arguments
+        parser = create_parser()
+        namespace = parser.parse_args()
+        args = CliArgs.from_namespace(namespace)
+
+        # load input data and mapping configuration
+        mapping_config = load_mapping(args)
+        input_data = load_input(args)
+
+        # transform the input data using the mapping configuration
+        output_data = transform_input(
+            data=input_data,
+            mapping=mapping_config,
+        )
+
+        # write the output data to the output file or stdout
+        write_output(output_data, args)
+        return 0
+
+    # handle errors
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in file - {e.msg}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/json_mapper/transform.py
+++ b/json_mapper/transform.py
@@ -85,7 +85,6 @@ DEFAULT_HANDLERS: dict[str, handler_func] = {
 def transform_from_mapping(
     data: dict,
     mapping: dict,
-    depth: int = 0,
     max_depth: int = 500,
     handlers: dict[str, handler_func] = DEFAULT_HANDLERS,
 ) -> dict:
@@ -100,7 +99,6 @@ def transform_from_mapping(
     Args:
         data: The source data dictionary to transform
         mapping: A dictionary describing how to transform the data
-        depth: Current recursion depth (used internally)
         max_depth: Maximum allowed recursion depth
         handlers: A dictionary of handler functions to use for the transformations
 
@@ -134,11 +132,7 @@ def transform_from_mapping(
     }
     ```
     """
-    # Check for maximum depth
-    # This is a sanity check to prevent stack overflow from deeply nested mappings
-    # which may be a concern when running this function on third-party mappings
-    if depth > max_depth:
-        raise ValueError("Maximum transformation depth exceeded.")
+    depth = 0
 
     def transform_node(node: Any, depth: int) -> Any:  # type: ignore [no-any-return]
         # Check for maximum depth
@@ -158,7 +152,7 @@ def transform_from_mapping(
             # If the key is a reserved word, call the matching handler function
             # on the value and return the result.
             # Node: `{ "field": "opportunity_status" }`
-            # Returns: `extract_field_value(data, "opportunity_status")`
+            # Returns: `pluck_field_value(data, "opportunity_status")`
             if k in handlers:
                 handler_func = handlers[k]
                 return handler_func(data, v)

--- a/json_mapper/transform.py
+++ b/json_mapper/transform.py
@@ -1,0 +1,185 @@
+"""
+This module provides a utility function for transforming data using a mapping.
+
+The transform_from_mapping function takes a data dictionary and a mapping dictionary.
+The mapping dictionary describes how to transform the data dictionary into a new dictionary.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+handler_func = Callable[[dict, Any], Any]
+
+# ############################################################
+# Handler Functions
+# ############################################################
+
+
+def get_from_path(data: dict, path: str, default: Any = None) -> Any:
+    """
+    Gets a value from a dictionary using dot notation.
+
+    Args:
+        data: The dictionary to extract the value from
+        path: A dot-separated string representing the path to the value
+        default: The default value to return if the path doesn't exist
+
+    Returns:
+        The value at the specified path, or the default value if the path doesn't exist
+    """
+    parts = path.split(".")
+    for part in parts:
+        if isinstance(data, dict) and part in data:
+            data = data[part]
+        else:
+            return default
+    return data
+
+
+def pluck_field_value(data: dict, field_path: str) -> Any:
+    """
+    Handles a field transformation by extracting a value from the data using
+    the specified field path.
+
+    Args:
+        data: The source data dictionary
+        field_path: A dot-separated string representing the path to the value
+
+    Returns:
+        The value from the specified field path in the data
+    """
+    return get_from_path(data, field_path)
+
+
+def switch_on_value(data: dict, switch_spec: dict) -> Any:
+    """
+    Handles a match transformation by looking up a value in a case dictionary.
+
+    Args:
+        data: The source data dictionary
+        switch_spec: A dictionary containing:
+            - 'field': The field path to get the value from
+            - 'case': A dictionary mapping values to their transformations
+            - 'default': (optional) The default value if no match is found
+
+    Returns:
+        The transformed value based on the match, or the default value if no match is found
+    """
+    val = get_from_path(data, switch_spec.get("field", ""))
+    lookup = switch_spec.get("case", {})
+    return lookup.get(val, switch_spec.get("default"))
+
+
+# Registry for handlers
+DEFAULT_HANDLERS: dict[str, handler_func] = {
+    "field": pluck_field_value,
+    "switch": switch_on_value,
+}
+
+
+# ############################################################
+# Transform Function
+# ############################################################
+
+
+def transform_from_mapping(
+    data: dict,
+    mapping: dict,
+    depth: int = 0,
+    max_depth: int = 500,
+    handlers: dict[str, handler_func] = DEFAULT_HANDLERS,
+) -> dict:
+    """
+    Transforms a data dictionary according to a mapping specification.
+
+    The mapping supports both literal values and transformations keyed by
+    the following reserved words:
+    - `field`: Extracts a value from the data using a dot-notation path
+    - `switch`: Performs a case-based lookup based on a field value
+
+    Args:
+        data: The source data dictionary to transform
+        mapping: A dictionary describing how to transform the data
+        depth: Current recursion depth (used internally)
+        max_depth: Maximum allowed recursion depth
+        handlers: A dictionary of handler functions to use for the transformations
+
+    Returns:
+        A new dictionary containing the transformed data according to the mapping
+
+    Example:
+
+    ```python
+    source_data = {
+        "opportunity_status": "closed",
+        "opportunity_amount": 1000,
+    }
+
+    mapping = {
+        "status": { "field": "opportunity_status" },
+        "amount": {
+            "value": { "field": "opportunity_amount" },
+            "currency": "USD",
+        },
+    }
+
+    result = transform_from_mapping(source_data, mapping)
+
+    assert result == {
+        "status": "closed",
+        "amount": {
+            "value": 1000,
+            "currency": "USD",
+        },
+    }
+    ```
+    """
+    # Check for maximum depth
+    # This is a sanity check to prevent stack overflow from deeply nested mappings
+    # which may be a concern when running this function on third-party mappings
+    if depth > max_depth:
+        raise ValueError("Maximum transformation depth exceeded.")
+
+    def transform_node(node: Any, depth: int) -> Any:
+        # Check for maximum depth
+        # This is a sanity check to prevent stack overflow from deeply nested mappings
+        # which may be a concern when running this function on third-party mappings
+        if depth > max_depth:
+            raise ValueError("Maximum transformation depth exceeded.")
+
+        # If the node is not a dictionary, return as is
+        # This allows users to set a key to a constant value (string or number)
+        if not isinstance(node, dict):
+            return node
+
+        # Walk through each key in the current node
+        for k, v in node.items():
+
+            # If the key is a reserved word, call the matching handler function
+            # on the value and return the result.
+            # Node: `{ "field": "opportunity_status" }`
+            # Returns: `extract_field_value(data, "opportunity_status")`
+            if k in handlers:
+                handler_func = handlers[k]
+                return handler_func(data, v)
+
+            # Otherwise, preserve the dictionary structure and
+            # recursively apply the transformation to each value.
+            # Node:
+            # ```
+            # {
+            #   "status": { "field": "opportunity_status" },
+            #   "amount": { "field": "opportunity_amount" },
+            # }
+            # ```
+            # Returns:
+            # ```
+            # {
+            #   "status": transform_node({ "field": "opportunity_status" }, depth + 1)
+            #   "amount": transform_node({ "field": "opportunity_amount" }, depth + 1)
+            # }
+            # ```
+            return {k: transform_node(v, depth + 1) for k, v in node.items()}
+
+    # Recursively walk the mapping until all nested transformations are applied
+    return transform_node(mapping, depth)

--- a/json_mapper/transform.py
+++ b/json_mapper/transform.py
@@ -140,7 +140,7 @@ def transform_from_mapping(
     if depth > max_depth:
         raise ValueError("Maximum transformation depth exceeded.")
 
-    def transform_node(node: Any, depth: int) -> Any:
+    def transform_node(node: Any, depth: int) -> Any:  # type: ignore [no-any-return]
         # Check for maximum depth
         # This is a sanity check to prevent stack overflow from deeply nested mappings
         # which may be a concern when running this function on third-party mappings
@@ -182,4 +182,4 @@ def transform_from_mapping(
             return {k: transform_node(v, depth + 1) for k, v in node.items()}
 
     # Recursively walk the mapping until all nested transformations are applied
-    return transform_node(mapping, depth)
+    return transform_node(mapping, depth)  # type: ignore [no-any-return]

--- a/json_mapper/transform.py
+++ b/json_mapper/transform.py
@@ -70,10 +70,20 @@ def switch_on_value(data: dict, switch_spec: dict) -> Any:
     return lookup.get(val, switch_spec.get("default"))
 
 
+def concat_values(data: dict, concat_spec: dict) -> Any:
+    """
+    Handles a concatenation transformation by joining multiple values together.
+    """
+    return "".join(
+        str(transform_from_mapping(data, part)) for part in concat_spec["parts"]
+    )
+
+
 # Registry for handlers
 DEFAULT_HANDLERS: dict[str, handler_func] = {
     "field": pluck_field_value,
     "switch": switch_on_value,
+    "concat": concat_values,
 }
 
 

--- a/json_mapper/utils.py
+++ b/json_mapper/utils.py
@@ -1,0 +1,45 @@
+"""Common utility functions for json-mapper."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json_file(file_path: str) -> dict[str, Any]:
+    """Load and parse a JSON file.
+
+    Args:
+        file_path: Path to the JSON file
+
+    Returns:
+        Parsed JSON data as a dictionary
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        json.JSONDecodeError: If the file contains invalid JSON
+        TypeError: If the JSON content is not an object
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with path.open("r") as f:
+        data = json.load(f)
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected JSON object, got {type(data).__name__}")
+        return data
+
+
+def save_json_file(data: dict[str, Any], file_path: str, indent: int = 2) -> None:
+    """Save data to a JSON file.
+
+    Args:
+        data: Dictionary to save as JSON
+        file_path: Path where the JSON file should be saved
+        indent: Number of spaces for indentation (default: 2)
+    """
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w") as f:
+        json.dump(data, f, indent=indent)

--- a/json_mapper/utils.py
+++ b/json_mapper/utils.py
@@ -30,7 +30,11 @@ def load_json_file(file_path: str) -> dict[str, Any]:
         return data
 
 
-def save_json_file(data: dict[str, Any], file_path: str, indent: int = 2) -> None:
+def save_json_file(
+    data: dict[str, Any],
+    file_path: str,
+    indent: int = 2,
+) -> None:
     """Save data to a JSON file.
 
     Args:

--- a/poetry.lock
+++ b/poetry.lock
@@ -532,6 +532,89 @@ files = [
 dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.13"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -575,4 +658,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "31ab0b726349042fe8d797b5f7052e7c1ea5756baa46bc6df51e35a126d73c0f"
+content-hash = "b02770a0b7599e476a38ca89732f516a8c135d3661642b71fc77401b6ecc705d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = [
   {name = "widal001", email = "billy.daly@agile6.com"},
 ]
-dependencies = []
+dependencies = ["pyyaml (>=6.0.3,<7.0.0)"]
 description = "Translates JSON values from one format to another using a declarative mapping config"
 name = "json-mapper"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ exclude_lines = [
 ]
 
 [tool.black]
-line-length = 100
+line-length = 80
 target-version = ["py313"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ exclude_lines = [
 ]
 
 [tool.black]
-line-length = 80
+line-length = 88
 target-version = ["py313"]
 
 [tool.ruff]
@@ -52,7 +52,7 @@ target-version = "py313"
 
 [tool.ruff.lint]
 ignore = []
-select = ["E", "F", "I", "N", "W", "UP"]
+select = ["E", "F", "I", "N", "W", "UP", "COM"]
 
 [tool.mypy]
 disallow_incomplete_defs = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,77 +1,61 @@
 """Tests for the CLI module."""
 
-import json
-import tempfile
-from pathlib import Path
-
 import pytest
 
-from json_mapper.cli import load_json_file, save_json_file, map_json, create_parser
+from json_mapper.cli import (
+    CliArgs,
+    create_parser,
+    load_input,
+    load_mapping,
+    transform_input,
+)
 
 
-class TestLoadJsonFile:
-    """Tests for load_json_file function."""
+class TestLoadMapping:
+    """Tests for load_mapping function."""
 
-    def test_load_valid_json(self, tmp_path: Path) -> None:
-        """Test loading a valid JSON file."""
-        test_file = tmp_path / "test.json"
-        test_data = {"key": "value", "number": 42}
-        test_file.write_text(json.dumps(test_data))
+    def test_load_mapping(self, tmp_path) -> None:
+        """Test loading a mapping configuration file."""
+        import json
 
-        result = load_json_file(str(test_file))
-        assert result == test_data
+        mapping_file = tmp_path / "mapping.json"
+        mapping_data = {"field1": {"field": "source_field"}}
+        mapping_file.write_text(json.dumps(mapping_data))
 
-    def test_load_nonexistent_file(self) -> None:
-        """Test loading a file that doesn't exist."""
-        with pytest.raises(FileNotFoundError):
-            load_json_file("nonexistent.json")
+        args = CliArgs(mapping=str(mapping_file))
+        result = load_mapping(args)
 
-    def test_load_invalid_json(self, tmp_path: Path) -> None:
-        """Test loading a file with invalid JSON."""
-        test_file = tmp_path / "invalid.json"
-        test_file.write_text("not valid json {")
-
-        with pytest.raises(json.JSONDecodeError):
-            load_json_file(str(test_file))
+        assert result == mapping_data
 
 
-class TestSaveJsonFile:
-    """Tests for save_json_file function."""
+class TestLoadInput:
+    """Tests for load_input function."""
 
-    def test_save_json(self, tmp_path: Path) -> None:
-        """Test saving JSON to a file."""
-        test_file = tmp_path / "output.json"
-        test_data = {"key": "value", "nested": {"data": [1, 2, 3]}}
+    def test_load_input_from_file(self, tmp_path) -> None:
+        """Test loading input from a file."""
+        import json
 
-        save_json_file(test_data, str(test_file))
-
-        assert test_file.exists()
-        loaded_data = json.loads(test_file.read_text())
-        assert loaded_data == test_data
-
-    def test_save_creates_directories(self, tmp_path: Path) -> None:
-        """Test that save_json_file creates parent directories."""
-        test_file = tmp_path / "subdir" / "nested" / "output.json"
-        test_data = {"test": "data"}
-
-        save_json_file(test_data, str(test_file))
-
-        assert test_file.exists()
-        assert test_file.parent.exists()
-
-
-class TestMapJson:
-    """Tests for map_json function."""
-
-    def test_map_json_placeholder(self) -> None:
-        """Test the placeholder map_json implementation."""
+        input_file = tmp_path / "input.json"
         input_data = {"key": "value"}
-        mapping_config = {"fields": {}}
+        input_file.write_text(json.dumps(input_data))
 
-        result = map_json(input_data, mapping_config)
+        args = CliArgs(mapping="mapping.json", input=str(input_file))
+        result = load_input(args)
 
-        # Currently just returns input data unchanged
         assert result == input_data
+
+
+class TestTransformInput:
+    """Tests for transform_input function."""
+
+    def test_transform_input(self) -> None:
+        """Test transforming input data with a mapping."""
+        input_data = {"source_field": "test_value"}
+        mapping = {"target_field": {"field": "source_field"}}
+
+        result = transform_input(input_data, mapping)
+
+        assert result == {"target_field": "test_value"}
 
 
 class TestCreateParser:
@@ -123,3 +107,45 @@ class TestCreateParser:
         assert args.verbose
         assert args.compact
         assert args.indent == 4
+
+
+class TestCliArgs:
+    """Tests for CliArgs dataclass."""
+
+    def test_from_namespace(self) -> None:
+        """Test creating CliArgs from argparse Namespace."""
+        parser = create_parser()
+        namespace = parser.parse_args(["-m", "mapping.json", "input.json"])
+        args = CliArgs.from_namespace(namespace)
+
+        assert args.mapping == "mapping.json"
+        assert args.input == "input.json"
+        assert args.output is None
+        assert args.indent == 2
+        assert not args.compact
+        assert not args.verbose
+
+    def test_from_namespace_all_options(self) -> None:
+        """Test creating CliArgs with all options."""
+        parser = create_parser()
+        namespace = parser.parse_args(
+            [
+                "input.json",
+                "-m",
+                "mapping.json",
+                "-o",
+                "output.json",
+                "-v",
+                "--compact",
+                "--indent",
+                "4",
+            ]
+        )
+        args = CliArgs.from_namespace(namespace)
+
+        assert args.mapping == "mapping.json"
+        assert args.input == "input.json"
+        assert args.output == "output.json"
+        assert args.indent == 4
+        assert args.compact
+        assert args.verbose

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,9 @@
 """Tests for the CLI module."""
 
+import json
+import sys
+from unittest.mock import patch
+
 import pytest
 
 from json_mapper.cli import (
@@ -7,7 +11,9 @@ from json_mapper.cli import (
     create_parser,
     load_input,
     load_mapping,
+    main,
     transform_input,
+    write_output,
 )
 
 
@@ -16,16 +22,31 @@ class TestLoadMapping:
 
     def test_load_mapping(self, tmp_path) -> None:
         """Test loading a mapping configuration file."""
-        import json
-
         mapping_file = tmp_path / "mapping.json"
         mapping_data = {"field1": {"field": "source_field"}}
         mapping_file.write_text(json.dumps(mapping_data))
 
-        args = CliArgs(mapping=str(mapping_file))
+        args = CliArgs(mapping=str(mapping_file), input="input.json")
         result = load_mapping(args)
 
         assert result == mapping_data
+
+    def test_load_mapping_nonexistent_file(self, tmp_path) -> None:
+        """Test loading a non-existent mapping file."""
+        args = CliArgs(mapping=str(tmp_path / "nonexistent.json"), input="input.json")
+
+        with pytest.raises(FileNotFoundError):
+            load_mapping(args)
+
+    def test_load_mapping_invalid_json(self, tmp_path) -> None:
+        """Test loading an invalid JSON mapping file."""
+        mapping_file = tmp_path / "invalid.json"
+        mapping_file.write_text("{ invalid json }")
+
+        args = CliArgs(mapping=str(mapping_file), input="input.json")
+
+        with pytest.raises(json.JSONDecodeError):
+            load_mapping(args)
 
 
 class TestLoadInput:
@@ -33,8 +54,6 @@ class TestLoadInput:
 
     def test_load_input_from_file(self, tmp_path) -> None:
         """Test loading input from a file."""
-        import json
-
         input_file = tmp_path / "input.json"
         input_data = {"key": "value"}
         input_file.write_text(json.dumps(input_data))
@@ -43,6 +62,13 @@ class TestLoadInput:
         result = load_input(args)
 
         assert result == input_data
+
+    def test_load_input_nonexistent_file(self, tmp_path) -> None:
+        """Test loading from a non-existent input file."""
+        args = CliArgs(mapping="mapping.json", input=str(tmp_path / "nonexistent.json"))
+
+        with pytest.raises(FileNotFoundError):
+            load_input(args)
 
 
 class TestTransformInput:
@@ -57,6 +83,33 @@ class TestTransformInput:
 
         assert result == {"target_field": "test_value"}
 
+    def test_transform_input_complex_mapping(self) -> None:
+        """Test transforming with a complex nested mapping."""
+        input_data = {
+            "user": {"name": "John", "status": "active"},
+            "amount": 100,
+        }
+        mapping = {
+            "person": {
+                "fullName": {"field": "user.name"},
+                "isActive": {
+                    "switch": {
+                        "field": "user.status",
+                        "case": {"active": True, "inactive": False},
+                        "default": None,
+                    },
+                },
+            },
+            "total": {"field": "amount"},
+        }
+
+        result = transform_input(input_data, mapping)
+
+        assert result == {
+            "person": {"fullName": "John", "isActive": True},
+            "total": 100,
+        }
+
 
 class TestCreateParser:
     """Tests for create_parser function."""
@@ -66,23 +119,35 @@ class TestCreateParser:
         parser = create_parser()
         assert parser.prog == "json-mapper"
 
-    def test_parser_required_arguments(self) -> None:
-        """Test that mapping argument is required."""
+    def test_parser_missing_all_arguments(self) -> None:
+        """Test that required arguments are enforced."""
         parser = create_parser()
 
         with pytest.raises(SystemExit):
             parser.parse_args([])
 
-    def test_parser_with_mapping(self) -> None:
-        """Test parser with required mapping argument."""
+    def test_parser_missing_mapping(self) -> None:
+        """Test that mapping argument is required."""
         parser = create_parser()
-        args = parser.parse_args(["-m", "mapping.json"])
 
+        with pytest.raises(SystemExit):
+            parser.parse_args(["input.json"])
+
+    def test_parser_missing_input(self) -> None:
+        """Test that input argument is required."""
+        parser = create_parser()
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["-m", "mapping.json"])
+
+    def test_parser_with_required_arguments(self) -> None:
+        """Test parser with required arguments."""
+        parser = create_parser()
+        args = parser.parse_args(["input.json", "-m", "mapping.json"])
+
+        assert args.input == "input.json"
         assert args.mapping == "mapping.json"
-        assert args.input is None
         assert args.output is None
-        assert not args.verbose
-        assert not args.compact
 
     def test_parser_all_arguments(self) -> None:
         """Test parser with all arguments."""
@@ -94,18 +159,14 @@ class TestCreateParser:
                 "mapping.json",
                 "-o",
                 "output.json",
-                "-v",
-                "--compact",
                 "--indent",
                 "4",
-            ]
+            ],
         )
 
         assert args.input == "input.json"
         assert args.mapping == "mapping.json"
         assert args.output == "output.json"
-        assert args.verbose
-        assert args.compact
         assert args.indent == 4
 
 
@@ -122,8 +183,6 @@ class TestCliArgs:
         assert args.input == "input.json"
         assert args.output is None
         assert args.indent == 2
-        assert not args.compact
-        assert not args.verbose
 
     def test_from_namespace_all_options(self) -> None:
         """Test creating CliArgs with all options."""
@@ -135,11 +194,9 @@ class TestCliArgs:
                 "mapping.json",
                 "-o",
                 "output.json",
-                "-v",
-                "--compact",
                 "--indent",
                 "4",
-            ]
+            ],
         )
         args = CliArgs.from_namespace(namespace)
 
@@ -147,5 +204,228 @@ class TestCliArgs:
         assert args.input == "input.json"
         assert args.output == "output.json"
         assert args.indent == 4
-        assert args.compact
-        assert args.verbose
+
+
+class TestWriteOutput:
+    """Tests for write_output function."""
+
+    def test_write_output_to_file(self, tmp_path) -> None:
+        """Test writing output to a file."""
+        output_file = tmp_path / "output.json"
+        output_data = {"result": "success"}
+
+        args = CliArgs(
+            mapping="mapping.json",
+            input="input.json",
+            output=str(output_file),
+        )
+        write_output(output_data, args)
+
+        assert output_file.exists()
+        with output_file.open() as f:
+            loaded_data = json.load(f)
+        assert loaded_data == output_data
+
+    def test_write_output_to_stdout(self, capsys) -> None:
+        """Test writing output to stdout."""
+        output_data = {"result": "success"}
+
+        args = CliArgs(mapping="mapping.json", input="input.json", output=None)
+        write_output(output_data, args)
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out.strip()) == output_data
+
+    def test_write_output_custom_indent(self, tmp_path) -> None:
+        """Test writing output with custom indentation."""
+        output_file = tmp_path / "output.json"
+        output_data = {"result": "success", "data": {"nested": "value"}}
+
+        args = CliArgs(
+            mapping="mapping.json",
+            input="input.json",
+            output=str(output_file),
+            indent=4,
+        )
+        write_output(output_data, args)
+
+        # Read the file as text to check indentation
+        content = output_file.read_text()
+        # With indent=4, we should see 4 spaces before nested keys
+        assert "    " in content
+
+
+class TestMainIntegration:
+    """Integration tests for main function with various scenarios."""
+
+    def test_main_success(self, tmp_path) -> None:
+        """Test successful CLI execution."""
+        # Create input file
+        input_file = tmp_path / "input.json"
+        input_data = {"source": "value"}
+        input_file.write_text(json.dumps(input_data))
+
+        # Create mapping file
+        mapping_file = tmp_path / "mapping.json"
+        mapping_data = {"target": {"field": "source"}}
+        mapping_file.write_text(json.dumps(mapping_data))
+
+        # Create output file path
+        output_file = tmp_path / "output.json"
+
+        test_args = [
+            "json-mapper",
+            str(input_file),
+            "-m",
+            str(mapping_file),
+            "-o",
+            str(output_file),
+        ]
+
+        with patch.object(sys, "argv", test_args):
+            exit_code = main()
+
+        assert exit_code == 0
+        assert output_file.exists()
+        with output_file.open() as f:
+            result = json.load(f)
+        assert result == {"target": "value"}
+
+    def test_main_file_not_found(self, tmp_path, capsys) -> None:
+        """Test CLI with non-existent input file."""
+        mapping_file = tmp_path / "mapping.json"
+        mapping_data = {"target": {"field": "source"}}
+        mapping_file.write_text(json.dumps(mapping_data))
+
+        test_args = [
+            "json-mapper",
+            str(tmp_path / "nonexistent.json"),
+            "-m",
+            str(mapping_file),
+        ]
+
+        with patch.object(sys, "argv", test_args):
+            exit_code = main()
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "Error:" in captured.err
+        assert "File not found" in captured.err
+
+    def test_main_invalid_json(self, tmp_path, capsys) -> None:
+        """Test CLI with invalid JSON input."""
+        input_file = tmp_path / "input.json"
+        input_file.write_text("{ invalid json }")
+
+        mapping_file = tmp_path / "mapping.json"
+        mapping_data = {"target": {"field": "source"}}
+        mapping_file.write_text(json.dumps(mapping_data))
+
+        test_args = [
+            "json-mapper",
+            str(input_file),
+            "-m",
+            str(mapping_file),
+        ]
+
+        with patch.object(sys, "argv", test_args):
+            exit_code = main()
+
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "Error: Invalid JSON in file" in captured.err
+
+
+class TestMainCLI:
+    """Tests for main function CLI arguments and flags."""
+
+    def test_main_missing_required_arguments(self) -> None:
+        """Test main function with missing required arguments."""
+        test_args = ["json-mapper"]
+
+        with patch.object(sys, "argv", test_args):
+            with pytest.raises(SystemExit):
+                main()
+
+    def test_main_missing_mapping_argument(self) -> None:
+        """Test main function with missing mapping argument."""
+        test_args = ["json-mapper", "input.json"]
+
+        with patch.object(sys, "argv", test_args):
+            with pytest.raises(SystemExit):
+                main()
+
+    def test_main_with_version(self, capsys) -> None:
+        """Test main function with --version flag."""
+        test_args = ["json-mapper", "--version"]
+
+        with patch.object(sys, "argv", test_args):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+
+        assert excinfo.value.code == 0
+        captured = capsys.readouterr()
+        assert "0.1.0" in captured.out
+
+    def test_main_help(self, capsys) -> None:
+        """Test main function with --help flag."""
+        test_args = ["json-mapper", "--help"]
+
+        with patch.object(sys, "argv", test_args):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+
+        assert excinfo.value.code == 0
+        captured = capsys.readouterr()
+        assert "json-mapper" in captured.out
+        assert "Translate JSON values" in captured.out
+
+    def test_main_end_to_end(self, tmp_path) -> None:
+        """Test complete end-to-end CLI workflow."""
+        # Create a more complex scenario
+        input_file = tmp_path / "input.json"
+        input_data = {
+            "user": {"name": "Alice", "type": "admin"},
+            "value": 42,
+        }
+        input_file.write_text(json.dumps(input_data))
+
+        mapping_file = tmp_path / "mapping.json"
+        mapping_data = {
+            "userName": {"field": "user.name"},
+            "role": {
+                "switch": {
+                    "field": "user.type",
+                    "case": {"admin": "Administrator", "user": "Regular User"},
+                    "default": "Unknown",
+                },
+            },
+            "data": {"amount": {"field": "value"}, "currency": "USD"},
+        }
+        mapping_file.write_text(json.dumps(mapping_data))
+
+        output_file = tmp_path / "output.json"
+
+        test_args = [
+            "json-mapper",
+            str(input_file),
+            "-m",
+            str(mapping_file),
+            "-o",
+            str(output_file),
+        ]
+
+        with patch.object(sys, "argv", test_args):
+            exit_code = main()
+
+        assert exit_code == 0
+
+        with output_file.open() as f:
+            result = json.load(f)
+
+        expected = {
+            "userName": "Alice",
+            "role": "Administrator",
+            "data": {"amount": 42, "currency": "USD"},
+        }
+        assert result == expected

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -171,7 +171,9 @@ class TestNestedStructures:
         nested objects is preserved.
         """
         mapping = {
-            "level1": {"level2": {"val": {"field": "summary.forecasted_award_date"}}},
+            "level1": {
+                "level2": {"val": {"field": "summary.forecasted_award_date"}},
+            },
         }
         result = transform_from_mapping(input_data, mapping)
         assert result == {"level1": {"level2": {"val": "2025-09-01"}}}
@@ -195,6 +197,34 @@ class TestListHandling:
 class TestCustomHandlers:
     """Tests for extending the transformation system with custom handlers."""
 
+    def test_multiply_handler(self, input_data):
+        """
+        Test custom handler for multiplying numeric values.
+
+        Verifies that custom handlers can be added to the transformation system,
+        the multiply handler can scale numeric values by a factor, and the
+        handler works with field values.
+        """
+
+        # Patch in a multiply handler for this test
+        def handle_multiply(data, multiply_spec):
+            value = transform_from_mapping(data, multiply_spec["value"])
+            factor = multiply_spec["by"]
+            return value * factor
+
+        DEFAULT_HANDLERS["multiply"] = handle_multiply
+
+        mapping = {
+            "max_award_doubled": {
+                "multiply": {
+                    "value": {"field": "summary.award_ceiling"},
+                    "by": 2,
+                },
+            },
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"max_award_doubled": 200000}
+
     def test_concat_handler(self, input_data):
         """
         Test custom handler for concatenating values.
@@ -207,7 +237,8 @@ class TestCustomHandlers:
         # Patch in a concat handler for this test
         def handle_concat(data, concat_spec):
             return "".join(
-                str(transform_from_mapping(data, part)) for part in concat_spec["parts"]
+                str(transform_from_mapping(data, part))
+                for part in concat_spec["parts"]
             )
 
         DEFAULT_HANDLERS["concat"] = handle_concat
@@ -250,7 +281,9 @@ class TestCustomHandlers:
         }
 
         mapping = {
-            "id_str": {"type": {"value": {"field": "opportunity_id"}, "to": "string"}},
+            "id_str": {
+                "type": {"value": {"field": "opportunity_id"}, "to": "string"},
+            },
         }
         result = transform_from_mapping(input_data, mapping, handlers=handlers)
         assert result == {"id_str": "12345"}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,263 @@
+"""Tests for the transform module."""
+
+import pytest
+
+from json_mapper.transform import (
+    DEFAULT_HANDLERS,
+    transform_from_mapping,
+)
+
+
+@pytest.fixture(name="input_data")
+def input_data_fixture():
+    """Fixture providing sample input data for transformation tests."""
+    return {
+        "agency_name": "Department of Examples",
+        "opportunity_id": 12345,
+        "opportunity_number": "ABC-123-XYZ-001",
+        "opportunity_status": "posted",
+        "opportunity_title": "Research into ABC",
+        "summary": {
+            "applicant_types": ["state_governments", "nonprofit"],
+            "archive_date": "2025-05-01",
+            "award_ceiling": 100000,
+            "award_floor": 10000,
+            "forecasted_award_date": "2025-09-01",
+            "forecasted_close_date": "2025-07-15",
+            "forecasted_post_date": "2025-05-01",
+        },
+    }
+
+
+class TestBasicTransformations:
+    """Tests for basic transformation operations."""
+
+    def test_field_extraction(self, input_data):
+        """
+        Test basic field extraction from input data.
+
+        Verifies that field values can be extracted from the input data.
+        """
+        mapping = {"title": {"field": "opportunity_title"}}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"title": "Research into ABC"}
+
+    def test_constant_value(self, input_data):
+        """
+        Test setting constant values in the output.
+
+        Verifies that constant values can be set in the output.
+        """
+        mapping = {"agency": "Example Agency"}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"agency": "Example Agency"}
+
+    def test_field_and_constant_combined(self, input_data):
+        """
+        Test combining field extraction and constant values.
+
+        Verifies that both field values and constants can be used in the same
+        transformation.
+        """
+        mapping = {
+            "title": {"field": "opportunity_title"},
+            "agency": "Example Agency",
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {
+            "title": "Research into ABC",
+            "agency": "Example Agency",
+        }
+
+    def test_literal_value(self, input_data):
+        """
+        Test handling of literal values in the mapping.
+
+        Verifies that literal values are passed through unchanged and
+        non-dictionary values are treated as literals.
+        """
+        mapping = {"static": 42}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"static": 42}
+
+
+class TestSwitchHandler:
+    """Tests for the switch/match transformation handler."""
+
+    def test_switch_with_match(self, input_data):
+        """
+        Test the switch transformation handler with a matching value.
+
+        Verifies that values can be transformed based on matching conditions.
+        """
+        mapping = {
+            "status": {
+                "switch": {
+                    "field": "opportunity_status",
+                    "case": {
+                        "forecasted": "forecasted",
+                        "posted": "open",
+                        "archived": "closed",
+                    },
+                    "default": "custom",
+                }
+            }
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"status": "open"}
+
+    def test_switch_with_nested_object(self, input_data):
+        """
+        Test combination of switch transformations within nested structures.
+
+        Verifies that switch transformations can be used within nested structures
+        and that constants can be used alongside switches in nested objects.
+        """
+        mapping = {
+            "status": {
+                "value": {
+                    "switch": {
+                        "field": "opportunity_status",
+                        "case": {
+                            "forecasted": "forecasted",
+                            "posted": "open",
+                            "archived": "closed",
+                        },
+                        "default": "custom",
+                    }
+                },
+                "description": "The opportunity is currently accepting applications",
+            }
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {
+            "status": {
+                "value": "open",
+                "description": "The opportunity is currently accepting applications",
+            }
+        }
+
+
+class TestNestedStructures:
+    """Tests for transformations involving nested object structures."""
+
+    def test_nested_object(self, input_data):
+        """
+        Test transformation of nested object structures.
+
+        Verifies that nested objects can be created in the output, field values
+        can be extracted from nested input paths, and constants can be used
+        within nested structures.
+        """
+        mapping = {
+            "funding": {
+                "minAwardAmount": {
+                    "amount": {"field": "summary.award_floor"},
+                    "currency": "USD",
+                }
+            }
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"funding": {"minAwardAmount": {"amount": 10000, "currency": "USD"}}}
+
+    def test_deeply_nested_structures(self, input_data):
+        """
+        Test transformation with deeply nested structures.
+
+        Verifies that the transformation system can handle deeply nested objects,
+        field paths can access deeply nested values, and the structure of deeply
+        nested objects is preserved.
+        """
+        mapping = {"level1": {"level2": {"val": {"field": "summary.forecasted_award_date"}}}}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"level1": {"level2": {"val": "2025-09-01"}}}
+
+
+class TestListHandling:
+    """Tests for handling list fields in transformations."""
+
+    def test_list_field_extraction(self, input_data):
+        """
+        Test extraction of list fields from the input data.
+
+        Verifies that list values can be extracted from the input data and
+        lists are preserved in their original form.
+        """
+        mapping = {"applicant_types": {"field": "summary.applicant_types"}}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"applicant_types": ["state_governments", "nonprofit"]}
+
+
+class TestCustomHandlers:
+    """Tests for extending the transformation system with custom handlers."""
+
+    def test_concat_handler(self, input_data):
+        """
+        Test custom handler for concatenating values.
+
+        Verifies that custom handlers can be added to the transformation system,
+        the concat handler can combine multiple transformed values, and the
+        handler works with both field values and constants.
+        """
+
+        # Patch in a concat handler for this test
+        def handle_concat(data, concat_spec):
+            return "".join(str(transform_from_mapping(data, part)) for part in concat_spec["parts"])
+
+        DEFAULT_HANDLERS["concat"] = handle_concat
+
+        mapping = {
+            "opportunity_code": {
+                "concat": {
+                    "parts": [
+                        {"field": "opportunity_number"},
+                        "-",
+                        {"field": "opportunity_id"},
+                    ]
+                }
+            }
+        }
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"opportunity_code": "ABC-123-XYZ-001-12345"}
+
+    def test_type_conversion_handler(self, input_data):
+        """
+        Test custom handler for type conversion.
+
+        Verifies that custom handlers can perform type conversions, the type
+        handler can convert values to different types, and custom handlers can
+        be passed explicitly to transform_from_mapping.
+        """
+
+        def handle_type(data, type_spec):
+            value = transform_from_mapping(data, type_spec["value"])
+            typ = type_spec["to"]
+            if typ == "string":
+                return str(value)
+            elif typ == "number":
+                return float(value)  # type: ignore
+            return value
+
+        handlers = {
+            **DEFAULT_HANDLERS,
+            "type": handle_type,
+        }
+
+        mapping = {"id_str": {"type": {"value": {"field": "opportunity_id"}, "to": "string"}}}
+        result = transform_from_mapping(input_data, mapping, handlers=handlers)
+        assert result == {"id_str": "12345"}
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_missing_field_returns_none(self, input_data):
+        """
+        Test behavior when accessing non-existent fields.
+
+        Verifies that attempting to access a non-existent field returns None
+        and the transformation continues to work even with missing fields.
+        """
+        mapping = {"foo": {"field": "nonexistent"}}
+        result = transform_from_mapping(input_data, mapping)
+        assert result == {"foo": None}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -100,8 +100,8 @@ class TestSwitchHandler:
                         "archived": "closed",
                     },
                     "default": "custom",
-                }
-            }
+                },
+            },
         }
         result = transform_from_mapping(input_data, mapping)
         assert result == {"status": "open"}
@@ -124,17 +124,17 @@ class TestSwitchHandler:
                             "archived": "closed",
                         },
                         "default": "custom",
-                    }
+                    },
                 },
                 "description": "The opportunity is currently accepting applications",
-            }
+            },
         }
         result = transform_from_mapping(input_data, mapping)
         assert result == {
             "status": {
                 "value": "open",
                 "description": "The opportunity is currently accepting applications",
-            }
+            },
         }
 
 
@@ -154,11 +154,13 @@ class TestNestedStructures:
                 "minAwardAmount": {
                     "amount": {"field": "summary.award_floor"},
                     "currency": "USD",
-                }
-            }
+                },
+            },
         }
         result = transform_from_mapping(input_data, mapping)
-        assert result == {"funding": {"minAwardAmount": {"amount": 10000, "currency": "USD"}}}
+        assert result == {
+            "funding": {"minAwardAmount": {"amount": 10000, "currency": "USD"}},
+        }
 
     def test_deeply_nested_structures(self, input_data):
         """
@@ -168,7 +170,9 @@ class TestNestedStructures:
         field paths can access deeply nested values, and the structure of deeply
         nested objects is preserved.
         """
-        mapping = {"level1": {"level2": {"val": {"field": "summary.forecasted_award_date"}}}}
+        mapping = {
+            "level1": {"level2": {"val": {"field": "summary.forecasted_award_date"}}},
+        }
         result = transform_from_mapping(input_data, mapping)
         assert result == {"level1": {"level2": {"val": "2025-09-01"}}}
 
@@ -202,7 +206,9 @@ class TestCustomHandlers:
 
         # Patch in a concat handler for this test
         def handle_concat(data, concat_spec):
-            return "".join(str(transform_from_mapping(data, part)) for part in concat_spec["parts"])
+            return "".join(
+                str(transform_from_mapping(data, part)) for part in concat_spec["parts"]
+            )
 
         DEFAULT_HANDLERS["concat"] = handle_concat
 
@@ -213,9 +219,9 @@ class TestCustomHandlers:
                         {"field": "opportunity_number"},
                         "-",
                         {"field": "opportunity_id"},
-                    ]
-                }
-            }
+                    ],
+                },
+            },
         }
         result = transform_from_mapping(input_data, mapping)
         assert result == {"opportunity_code": "ABC-123-XYZ-001-12345"}
@@ -243,7 +249,9 @@ class TestCustomHandlers:
             "type": handle_type,
         }
 
-        mapping = {"id_str": {"type": {"value": {"field": "opportunity_id"}, "to": "string"}}}
+        mapping = {
+            "id_str": {"type": {"value": {"field": "opportunity_id"}, "to": "string"}},
+        }
         result = transform_from_mapping(input_data, mapping, handlers=handlers)
         assert result == {"id_str": "12345"}
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -234,15 +234,6 @@ class TestCustomHandlers:
         handler works with both field values and constants.
         """
 
-        # Patch in a concat handler for this test
-        def handle_concat(data, concat_spec):
-            return "".join(
-                str(transform_from_mapping(data, part))
-                for part in concat_spec["parts"]
-            )
-
-        DEFAULT_HANDLERS["concat"] = handle_concat
-
         mapping = {
             "opportunity_code": {
                 "concat": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,78 @@
+"""Tests for the utils module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from json_mapper.utils import load_json_file, save_json_file
+
+
+class TestLoadJsonFile:
+    """Tests for load_json_file function."""
+
+    def test_load_valid_json(self, tmp_path: Path) -> None:
+        """Test loading a valid JSON file."""
+        test_file = tmp_path / "test.json"
+        test_data = {"key": "value", "number": 42}
+        test_file.write_text(json.dumps(test_data))
+
+        result = load_json_file(str(test_file))
+        assert result == test_data
+
+    def test_load_nonexistent_file(self) -> None:
+        """Test loading a file that doesn't exist."""
+        with pytest.raises(FileNotFoundError):
+            load_json_file("nonexistent.json")
+
+    def test_load_invalid_json(self, tmp_path: Path) -> None:
+        """Test loading a file with invalid JSON."""
+        test_file = tmp_path / "invalid.json"
+        test_file.write_text("not valid json {")
+
+        with pytest.raises(json.JSONDecodeError):
+            load_json_file(str(test_file))
+
+    def test_load_non_object_json(self, tmp_path: Path) -> None:
+        """Test loading JSON that is not an object."""
+        test_file = tmp_path / "array.json"
+        test_file.write_text("[1, 2, 3]")
+
+        with pytest.raises(TypeError, match="Expected JSON object"):
+            load_json_file(str(test_file))
+
+
+class TestSaveJsonFile:
+    """Tests for save_json_file function."""
+
+    def test_save_json(self, tmp_path: Path) -> None:
+        """Test saving JSON to a file."""
+        test_file = tmp_path / "output.json"
+        test_data = {"key": "value", "nested": {"data": [1, 2, 3]}}
+
+        save_json_file(test_data, str(test_file))
+
+        assert test_file.exists()
+        loaded_data = json.loads(test_file.read_text())
+        assert loaded_data == test_data
+
+    def test_save_creates_directories(self, tmp_path: Path) -> None:
+        """Test that save_json_file creates parent directories."""
+        test_file = tmp_path / "subdir" / "nested" / "output.json"
+        test_data = {"test": "data"}
+
+        save_json_file(test_data, str(test_file))
+
+        assert test_file.exists()
+        assert test_file.parent.exists()
+
+    def test_save_with_custom_indent(self, tmp_path: Path) -> None:
+        """Test saving JSON with custom indentation."""
+        test_file = tmp_path / "output.json"
+        test_data = {"key": "value"}
+
+        save_json_file(test_data, str(test_file), indent=4)
+
+        content = test_file.read_text()
+        # Check that the file is indented with 4 spaces
+        assert '    "key"' in content


### PR DESCRIPTION
### Summary

Sets up transformation logic and simplifies CLI options

- Fixes #1 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Implements transformation logic in `transform.py`
- Reorganizes code and simplifies CLI args in `cli.py`
- Expands and re-organizes `tests/`
- Improves `README` documentation

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Run `make examples`
2. You should see the following printed to the console and a file created in `output/output.json`
```
==> Running examples...


==> Example 1: Print to stdout
poetry run json-mapper examples/input.json -m examples/mapping.json
{
  "title": "Research Grant",
  "opportunityCode": "ABC-123-12345",
  "status": "open",
  "agency": {
    "name": "Department of Examples",
    "type": "Federal"
  },
  "contact": {
    "name": "Jane Smith",
    "email": "jane.smith@example.gov",
    "phone": "555-0100"
  },
  "funding": {
    "minimum": 10000,
    "maximum": 100000,
    "currency": "USD"
  },
  "eligibility": [
    "state_governments",
    "nonprofit"
  ],
  "deadline": "2025-07-15"
}


==> Example 2: Print to file
poetry run json-mapper examples/input.json -m examples/mapping.json -o output/output.json
```

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="990" height="533" alt="Screenshot 2026-01-22 at 4 39 05 PM" src="https://github.com/user-attachments/assets/31910e8b-0856-40b4-802d-904515fc210a" />

